### PR TITLE
Right keypoints

### DIFF
--- a/scripts/contour.py
+++ b/scripts/contour.py
@@ -8,7 +8,7 @@ import numpy as np
 import math
 
 
-def cont(path):
+def cont(path, show_lines = False, show_points = False):
 
     # Calls ML keypoints function and reads image
     inp = auto.dist(path)
@@ -25,14 +25,15 @@ def cont(path):
     # Get biggest contour of image
     contours, hierarchy = cv.findContours(thresh, cv.RETR_TREE, cv.CHAIN_APPROX_SIMPLE)
     contours = max(contours, key=lambda x: cv.contourArea(x))
-    #cv.drawContours(img, [contours], -1, (255,255,0), 2)
-    # To see contour, uncomment line above
 
-    """ img = cv.circle(img, (inp[4], inp[6]), 2, (255, 0, 0), 2)
-    img = cv.circle(img, (inp[5], inp[7]), 2, (255, 0, 0), 2)
-    img = cv.circle(img, (inp[1], inp[3]), 2, (0, 0, 255), 2)
-    img = cv.circle(img, (inp[0], inp[2]), 2, (0, 0, 255), 2) """
-    # To see the 4 important keypoints, uncomment lines above
+    if show_lines:
+        cv.drawContours(img, [contours], -1, (255,255,0), 2)
+
+    if show_points:
+        img = cv.circle(img, (inp[4], inp[6]), 2, (255, 0, 0), 2)
+        img = cv.circle(img, (inp[5], inp[7]), 2, (255, 0, 0), 2)
+        img = cv.circle(img, (inp[1], inp[3]), 2, (0, 0, 255), 2)
+        img = cv.circle(img, (inp[0], inp[2]), 2, (0, 0, 255), 2) 
 
     # Equation of line (normal linear equation)
     def line_eq(X):
@@ -46,8 +47,8 @@ def cont(path):
     x = np.arange(0, img_size[0])
     y = line(x).astype('int64')
 
-    #cv.line(img, (x[0], y[0]), (x[height-1], y[height-1]), (0,0,0))
-    # To draw the line, uncomment line above
+    if show_lines:
+        cv.line(img, (x[0], y[0]), (x[height-1], y[height-1]), (0,0,0))
 
     # Creates two black images, one with contour and another with line in white
     blank = np.zeros(img.shape[0:2])
@@ -57,7 +58,6 @@ def cont(path):
     # Logical bitwise operation to define the intersection between those two images
     intersection = np.logical_and(im1, im2)
 
-    # List of tuples to save intersection indexes
     hpoints = []
     aux = []
     wpoints = []
@@ -81,16 +81,15 @@ def cont(path):
         if dist > old_dist:
             wpoints = [aux[i], aux[i+1], aux[i+2], aux[i+3]]
 
-
-    #img = cv.circle(img, (answ[4], answ[5]), 2, (0, 255, 0), 2)
-    #img = cv.circle(img, (answ[6], answ[7]), 2, (0, 255, 0), 2)
-    # To see intersection points, uncomment lines above
+    if show_points:
+        img = cv.circle(img, (wpoints[0], wpoints[1]), 2, (0, 255, 0), 2)
+        img = cv.circle(img, (wpoints[2], wpoints[3]), 2, (0, 255, 0), 2)
     
-    #img = cv.circle(img, (answ[0], answ[2]), 2, (0, 255, 0), 2)
-    #img = cv.circle(img, (answ[1], answ[3]), 2, (0, 255, 0), 2)
+        img = cv.circle(img, (hpoints[0], hpoints[2]), 2, (0, 255, 0), 2)
+        img = cv.circle(img, (hpoints[1], hpoints[3]), 2, (0, 255, 0), 2)
 
-    #cv.imshow("foo",img)
-    #cv.waitKey()
-    # If you uncommented any line for image visualization, uncomment lines above
+    if show_lines or show_points:
+        cv.imshow("foo",img)
+        cv.waitKey()
 
     return hpoints, wpoints

--- a/scripts/contour.py
+++ b/scripts/contour.py
@@ -58,11 +58,11 @@ def cont(path):
     intersection = np.logical_and(im1, im2)
 
     # List of tuples to save intersection indexes
-    answ = []
+    hpoints = []
     aux = []
-    aux2 = []
+    wpoints = []
 
-    answ += (inp[i] for i in range(4))
+    hpoints += (inp[i] for i in range(4))
 
     for i in range(height-1):
         for j in range(width-1):
@@ -79,9 +79,8 @@ def cont(path):
             )
 
         if dist > old_dist:
-            aux2 = [aux[i], aux[i+1], aux[i+2], aux[i+3]]
+            wpoints = [aux[i], aux[i+1], aux[i+2], aux[i+3]]
 
-    answ += aux2
 
     #img = cv.circle(img, (answ[4], answ[5]), 2, (0, 255, 0), 2)
     #img = cv.circle(img, (answ[6], answ[7]), 2, (0, 255, 0), 2)
@@ -90,8 +89,8 @@ def cont(path):
     #img = cv.circle(img, (answ[0], answ[2]), 2, (0, 255, 0), 2)
     #img = cv.circle(img, (answ[1], answ[3]), 2, (0, 255, 0), 2)
 
-    cv.imshow("foo",img)
-    cv.waitKey()
+    #cv.imshow("foo",img)
+    #cv.waitKey()
     # If you uncommented any line for image visualization, uncomment lines above
 
-    return answ
+    return hpoints, wpoints

--- a/scripts/contour.py
+++ b/scripts/contour.py
@@ -5,6 +5,7 @@
 import auto
 import cv2 as cv
 import numpy as np
+import math
 
 
 def cont(path):
@@ -58,25 +59,39 @@ def cont(path):
 
     # List of tuples to save intersection indexes
     answ = []
+    aux = []
+    aux2 = []
 
     answ += (inp[i] for i in range(4))
 
-    for i in range(height-1, 0, -1):
-        for j in range(width-1, 0, -1):
+    for i in range(height-1):
+        for j in range(width-1):
             if intersection[i,j]:
-                answ.append(i)
-                answ.append(j)
+                aux.append(j)
+                aux.append(i)
 
+    dist = 0
+    for i in range(0,(len(aux)-2),2):
+        old_dist = dist
+        
+        dist = math.sqrt(
+                ((aux[i] - aux[i+2]) ** 2) + ((aux[i+1] - aux[i+3]) ** 2)
+            )
 
-    #img = cv.circle(img, (answ[5], answ[4]), 2, (0, 255, 0), 2)
-    #img = cv.circle(img, (answ[7], answ[6]), 2, (0, 255, 0), 2)
+        if dist > old_dist:
+            aux2 = [aux[i], aux[i+1], aux[i+2], aux[i+3]]
+
+    answ += aux2
+
+    #img = cv.circle(img, (answ[4], answ[5]), 2, (0, 255, 0), 2)
+    #img = cv.circle(img, (answ[6], answ[7]), 2, (0, 255, 0), 2)
     # To see intersection points, uncomment lines above
     
     #img = cv.circle(img, (answ[0], answ[2]), 2, (0, 255, 0), 2)
     #img = cv.circle(img, (answ[1], answ[3]), 2, (0, 255, 0), 2)
 
-    #cv.imshow("foo",img)
-    #cv.waitKey()
+    cv.imshow("foo",img)
+    cv.waitKey()
     # If you uncommented any line for image visualization, uncomment lines above
 
     return answ

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -77,7 +77,6 @@ while True:
         exit()
 
     if event in ('Automaticamente'):
-        new_path = rotate.rot(path)
         inp = contour.cont(path)
 
         dh = abs(inp[2] - inp[3])
@@ -158,9 +157,6 @@ while True:
     sg.popup_ok('G-Code gravado!') 
     break
 
-try: 
-    os.remove(new_path)
-except: pass
 
 #close GUI   
 window.close()

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -77,10 +77,10 @@ while True:
         exit()
 
     if event in ('Automaticamente'):
-        inp = contour.cont(path)
+        hpoints, wpoints = contour.cont(path)
 
-        dh = abs(inp[2] - inp[3])
-        dw = abs(inp[5] - inp[7])
+        dh = abs(hpoints[2] - hpoints[3])
+        dw = abs(wpoints[0] - wpoints[2])
 
         rt = scale.ratio(path)
         dh = dh * rt


### PR DESCRIPTION
## PR to correct keypoints bug:

When crossing keypoints width line and hand contour, sometimes we get more than 2 points. In this PR, the problem is solved, showing only the interesting points. Also, the rotate function is not used anymore.
To run, just execute `gui.py`, choose any image ("Gustavo.jpeg" is one of the images it occurred) and choose Automatic IP.

A few more feats/refactors were implemented:
- Split answ list into two lists: hpoints and wpoints;
- Change order of wpoints list, so that x coordinate come before y;
- Show lines and show points parameters added to contour function, just turn it True and it will show the image drawed with lines and points.